### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Brackets-Tern
 5. Live reload of .tern-project.  So, saving changes will automatically take effect without reloading Brackets. [Only for integrated tern and not for servers yet].
 6. Support for Meteor plugin!  Thanks to Slava for https://github.com/Slava/tern-meteor.
 7. ** Refactoring! To activate refactoring, place the editor's cursor on a variable/property and press `ctrl + r`.
-8. Refactoring is supported accross multiple files. EXPERIMENTAL
+8. Refactoring is supported across multiple files. EXPERIMENTAL
 9. Set the sorting order of your hints!
 
 


### PR DESCRIPTION
@MiguelCastillo, I've corrected a typographical error in the documentation of the [Brackets-Ternific](https://github.com/MiguelCastillo/Brackets-Ternific) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.