### PR TITLE
Added code to templetize settings with {project}, {tern}, {ternific}

### DIFF
--- a/.tern-project
+++ b/.tern-project
@@ -1,7 +1,7 @@
 {
   "libs": [
-    "./libs/tern/defs/reserved",
-    "./libs/tern/defs/lodash",
+    "{ternific}/libs/tern/defs/reserved",
+    "{ternific}/libs/tern/defs/lodash",
     "browser",
     "chai",
     "ecma5",

--- a/README.md
+++ b/README.md
@@ -33,7 +33,22 @@ FAQ
 
 `.tern-project` is the configuration file that ternific picks up to configure tern. This file can exist in any directory, and ternific will navigate up the directory hierarchy (up to the project), and use the first it finds.
 
-You can specify all you standard [tern](http://ternjs.net/doc/manual.html#configuration) settings. Additionally, you can specify directory *path* for `libs`, which allows you to specify custom definitions in your project. Take a look at [this](https://github.com/MiguelCastillo/Brackets-Ternific/blob/master/.tern-project#L3) example where ternific itself ships with a couple of custom lib definitions.
+You can specify all you standard [tern](http://ternjs.net/doc/manual.html#configuration) settings. Additionally, you can specify directory *path* for `libs` and `plugins` to load custom definitions and plugins. There are also a few template strings you can use to help you define paths relative to the your current project, ternific, or tern itself.
+
+```
+{
+  "libs": [
+    "{ternific}/libs/tern/defs/reserved",
+    "{ternific}/libs/tern/defs/lodash",
+    "browser",
+    "jquery"
+  ],
+  "plugins": {
+    "{project}/custom-plugin": {}
+  }
+}
+```
+
 
 
 Screenshots

--- a/Settings.js
+++ b/Settings.js
@@ -16,6 +16,8 @@ define(function (require /*, exports, module*/) {
     var EventDispatcher = brackets.getModule("utils/EventDispatcher");
     var Promise         = require("node_modules/spromise/dist/spromise.min");
 
+    var TERN_ROOT     = "node_modules/tern/";
+    var TERNIFIC_ROOT = "./";
 
     function Settings(filePath, watchProject) {
         this.project = ProjectManager.getProjectRoot();
@@ -137,6 +139,7 @@ define(function (require /*, exports, module*/) {
             }
             else {
                 return readFile(file)
+                    .then(configurePaths(settings), _.noop)
                     .then(parseSettings, _.noop)
                     .then(function(data) {
                         return {
@@ -160,7 +163,30 @@ define(function (require /*, exports, module*/) {
     }
 
 
-   /**
+    function configurePaths(settings) {
+        return function(settingsString) {
+            if (/{\w+}/.test(settingsString)) {
+                settingsString = settingsString.replace(/{\w+}/g, function(w) {
+                    if (w === "{project}") {
+                        return settings.baseUrl;
+                    }
+                    else if (w === "{tern}") {
+                        return TERN_ROOT;
+                    }
+                    else if (w === "{ternific}") {
+                        return TERNIFIC_ROOT;
+                    }
+
+                    return w;
+                });
+            }
+
+            return normalizePath(settingsString);
+        }
+    }
+
+
+    /**
      * Cleans out settings data. It removes all comments from the file before
      * it is converted to a JSON structure.
      *


### PR DESCRIPTION
This will let you do things like loading plugins and definitions. Here is a sample config file.

```
{
  "libs": [
    "{ternific}/libs/tern/defs/reserved",
    "{ternific}/libs/tern/defs/lodash",
    "browser",
    "chai",
    "ecma5",
    "ecma6",
    "browser",
    "jquery"
  ],
  "loadEagerly": [],
  "async": true,
  "plugins": {
    "modules": {},
    "requirejs": {},
    "doc_comment": {},
    "es_modules": true,
    "{project}/local-plugin": true
  }
}
```